### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,15 +15,15 @@ Kaviar
     :target: http://kaviar.readthedocs.org/en/latest/
     :alt: Documentation
 
-.. image:: https://pypip.in/version/kaviar/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/kaviar.svg?style=flat
     :target: https://pypi.python.org/pypi/kaviar/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/kaviar/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/kaviar.svg?style=flat
     :target: https://pypi.python.org/pypi/kaviar/
     :alt: Python versions
 
-.. image:: https://pypip.in/license/kaviar/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/kaviar.svg?style=flat
     :target: https://github.com/eisensheng/kaviar/blob/develop/COPYING
     :alt: MIT License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20kaviar))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `kaviar`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.